### PR TITLE
feat: Add --due-date flag to task tracker

### DIFF
--- a/task_tracker.py
+++ b/task_tracker.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
 """Task Tracker CLI — minimal task management via JSON storage."""
 
+import datetime
 import json
 import sys
 from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
+
+
+def parse_flag(args, flag):
+    """Extract a flag value from args list. Returns (value_or_none, remaining_args)."""
+    if flag not in args:
+        return None, args
+    idx = args.index(flag)
+    if idx + 1 >= len(args):
+        return None, args
+    value = args[idx + 1]
+    remaining = args[:idx] + args[idx + 2:]
+    return value, remaining
 
 
 def load_tasks():
@@ -22,15 +35,22 @@ def next_id(tasks):
     return max((t["id"] for t in tasks), default=0) + 1
 
 
-def cmd_add(title, priority="medium"):
+def cmd_add(title, priority="medium", due_date=None):
+    if due_date is not None:
+        try:
+            datetime.date.fromisoformat(due_date)
+        except ValueError:
+            print("Invalid due-date format. Use YYYY-MM-DD.")
+            return
     tasks = load_tasks()
-    task = {"id": next_id(tasks), "title": title, "status": "open", "priority": priority}
+    task = {"id": next_id(tasks), "title": title, "status": "open", "priority": priority, "due_date": due_date}
     tasks.append(task)
     save_tasks(tasks)
-    print(f"Added task #{task['id']}: {title} [{priority}]")
+    due_str = f" (due: {due_date})" if due_date else ""
+    print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -39,10 +59,14 @@ def cmd_list(status=None, sort_priority=False):
     PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
     if sort_priority:
         filtered.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
+    if sort_due:
+        filtered.sort(key=lambda t: (t.get("due_date") is None, t.get("due_date") or ""))
     for t in filtered:
         mark = "x" if t["status"] == "done" else " "
         priority = t.get("priority", "medium")
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]")
+        due_date = t.get("due_date")
+        due_str = f" (due: {due_date})" if due_date else ""
+        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
 
 
 def cmd_done(task_id):
@@ -78,27 +102,25 @@ def main():
 
     if command == "add":
         if len(args) < 2:
-            print("Usage: task_tracker.py add <title> [--priority low|medium|high]")
+            print("Usage: task_tracker.py add <title> [--priority low|medium|high] [--due-date YYYY-MM-DD]")
             sys.exit(1)
-        priority = "medium"
         add_args = args[1:]
-        if "--priority" in add_args:
-            idx = add_args.index("--priority")
-            if idx + 1 < len(add_args):
-                priority = add_args[idx + 1]
-            title_parts = add_args[:idx]
-        else:
-            title_parts = add_args
-        cmd_add(" ".join(title_parts), priority)
+        priority, add_args = parse_flag(add_args, "--priority")
+        if priority is None:
+            priority = "medium"
+        due_date, add_args = parse_flag(add_args, "--due-date")
+        title = " ".join(add_args)
+        cmd_add(title, priority, due_date)
 
     elif command == "list":
         status = None
         sort_priority = "--priority" in args
+        sort_due = "--sort-due" in args
         if "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority)
+        cmd_list(status, sort_priority, sort_due)
 
     elif command == "done":
         if len(args) < 2:

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -108,6 +108,65 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("[medium]", output)
 
+    def test_add_task_with_due_date(self):
+        task_tracker.cmd_add("Dated task", due_date="2026-05-01")
+        tasks = task_tracker.load_tasks()
+        self.assertEqual(tasks[0]["due_date"], "2026-05-01")
+
+    def test_add_task_default_due_date(self):
+        task_tracker.cmd_add("No date task")
+        tasks = task_tracker.load_tasks()
+        self.assertIsNone(tasks[0].get("due_date"))
+
+    def test_list_shows_due_date(self):
+        task_tracker.cmd_add("Dated task", due_date="2026-05-01")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("(due: 2026-05-01)", output)
+
+    def test_list_no_due_date_omitted(self):
+        task_tracker.cmd_add("Plain task")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("(due:", output)
+
+    def test_list_sorted_by_due_date(self):
+        task_tracker.cmd_add("Later task", due_date="2026-06-01")
+        task_tracker.cmd_add("Earlier task", due_date="2026-04-25")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(sort_due=True)
+        calls = [str(c) for c in mock_print.call_args_list]
+        earlier_idx = next(i for i, c in enumerate(calls) if "Earlier task" in c)
+        later_idx = next(i for i, c in enumerate(calls) if "Later task" in c)
+        self.assertLess(earlier_idx, later_idx)
+
+    def test_list_sort_due_date_none_last(self):
+        task_tracker.cmd_add("No date task")
+        task_tracker.cmd_add("Dated task", due_date="2026-04-25")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(sort_due=True)
+        calls = [str(c) for c in mock_print.call_args_list]
+        dated_idx = next(i for i, c in enumerate(calls) if "Dated task" in c)
+        undated_idx = next(i for i, c in enumerate(calls) if "No date task" in c)
+        self.assertLess(dated_idx, undated_idx)
+
+    def test_add_invalid_due_date(self):
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_add("Bad date task", due_date="not-a-date")
+        mock_print.assert_called_with("Invalid due-date format. Use YYYY-MM-DD.")
+        tasks = task_tracker.load_tasks()
+        self.assertEqual(len(tasks), 0)
+
+    def test_backward_compat_no_due_date(self):
+        tasks = [{"id": 1, "title": "Old task", "status": "open", "priority": "medium"}]
+        task_tracker.save_tasks(tasks)
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("(due:", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `--due-date YYYY-MM-DD` flag to the `add` command for attaching deadlines to tasks
- Displays due dates in `list` output and adds `--sort-due` flag to sort by deadline (undated tasks last)
- Validates date format and rejects invalid dates with a clear error message
- Adds `parse_flag()` helper to support multiple flags (`--priority` and `--due-date`) in any order

## Test plan

- [x] 21 unit tests pass (13 existing + 8 new)
- [x] Integration smoke test: add with due-date, list, sort-due, invalid date, reversed flag order
- [x] Backward compatibility: old tasks without `due_date` field display without errors

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)