### PR TITLE
feat: Add publish command for HTML task overview

### DIFF
--- a/task_tracker.py
+++ b/task_tracker.py
@@ -2,6 +2,7 @@
 """Task Tracker CLI — minimal task management via JSON storage."""
 
 import datetime
+import html
 import json
 import sys
 from pathlib import Path
@@ -91,11 +92,55 @@ def cmd_delete(task_id):
     print(f"Deleted task #{task_id}.")
 
 
+def cmd_publish():
+    tasks = load_tasks()
+    open_tasks = [t for t in tasks if t.get("status") == "open"]
+    PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+    open_tasks.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
+
+    if open_tasks:
+        rows = ""
+        for t in open_tasks:
+            priority = t.get("priority", "medium")
+            due_date = t.get("due_date") or "\u2014"
+            rows += (
+                f'<tr><td>{t["id"]}</td>'
+                f"<td>{html.escape(t['title'])}</td>"
+                f'<td class="{priority}">{priority}</td>'
+                f"<td>{due_date}</td></tr>\n"
+            )
+        body_content = (
+            "<table>\n<thead><tr>"
+            "<th>ID</th><th>Title</th><th>Priority</th><th>Due Date</th>"
+            "</tr></thead>\n<tbody>\n" + rows + "</tbody>\n</table>"
+        )
+    else:
+        body_content = "<p>No open tasks.</p>"
+
+    page = (
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
+        '<meta charset="UTF-8">\n<title>Open Tasks</title>\n<style>\n'
+        "body { font-family: sans-serif; max-width: 800px; margin: 2rem auto; }\n"
+        "table { border-collapse: collapse; width: 100%; }\n"
+        "th, td { border: 1px solid #ccc; padding: 0.5rem 1rem; text-align: left; }\n"
+        "th { background: #f5f5f5; }\n"
+        ".high { color: #c0392b; font-weight: bold; }\n"
+        ".medium { color: #e67e22; }\n"
+        ".low { color: #27ae60; }\n"
+        "</style>\n</head>\n<body>\n"
+        f"<h1>Open Tasks</h1>\n{body_content}\n"
+        "</body>\n</html>\n"
+    )
+
+    Path("tasks.html").write_text(page)
+    print(f"Published {len(open_tasks)} tasks to tasks.html")
+
+
 def main():
     args = sys.argv[1:]
     if not args:
         print("Usage: task_tracker.py <command> [args]")
-        print("Commands: add, list, done, delete")
+        print("Commands: add, list, done, delete, publish")
         sys.exit(1)
 
     command = args[0]
@@ -133,6 +178,9 @@ def main():
             print("Usage: task_tracker.py delete <id>")
             sys.exit(1)
         cmd_delete(int(args[1]))
+
+    elif command == "publish":
+        cmd_publish()
 
     else:
         print(f"Unknown command: {command}")

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
+PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
 
 
 def parse_flag(args, flag):
@@ -57,7 +58,6 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
     if not filtered:
         print("No tasks found.")
         return
-    PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
     if sort_priority:
         filtered.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
     if sort_due:
@@ -95,14 +95,13 @@ def cmd_delete(task_id):
 def cmd_publish():
     tasks = load_tasks()
     open_tasks = [t for t in tasks if t.get("status") == "open"]
-    PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
     open_tasks.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
 
     if open_tasks:
         rows = ""
         for t in open_tasks:
             priority = t.get("priority", "medium")
-            due_date = t.get("due_date") or "\u2014"
+            due_date = html.escape(t.get("due_date") or "\u2014")
             rows += (
                 f'<tr><td>{t["id"]}</td>'
                 f"<td>{html.escape(t['title'])}</td>"
@@ -133,7 +132,9 @@ def cmd_publish():
     )
 
     Path("tasks.html").write_text(page)
-    print(f"Published {len(open_tasks)} tasks to tasks.html")
+    count = len(open_tasks)
+    noun = "task" if count == 1 else "tasks"
+    print(f"Published {count} {noun} to tasks.html")
 
 
 def main():

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -168,5 +168,80 @@ class TestTaskTracker(unittest.TestCase):
         self.assertNotIn("(due:", output)
 
 
+class TestPublish(unittest.TestCase):
+    def setUp(self):
+        task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def tearDown(self):
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+        html_file = Path("tasks.html")
+        if html_file.exists():
+            html_file.unlink()
+
+    def test_publish_creates_html_file(self):
+        task_tracker.cmd_add("Test task", priority="high")
+        task_tracker.cmd_publish()
+        self.assertTrue(Path("tasks.html").exists())
+
+    def test_publish_prints_count(self):
+        task_tracker.cmd_add("Task one")
+        task_tracker.cmd_add("Task two")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_publish()
+        mock_print.assert_called_with("Published 2 tasks to tasks.html")
+
+    def test_publish_empty_tasks(self):
+        task_tracker.cmd_publish()
+        content = Path("tasks.html").read_text()
+        self.assertIn("No open tasks.", content)
+        self.assertIn("<!DOCTYPE html>", content)
+
+    def test_publish_only_open_tasks(self):
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_publish()
+        mock_print.assert_called_with("Published 1 tasks to tasks.html")
+        content = Path("tasks.html").read_text()
+        self.assertIn("Open task", content)
+        self.assertNotIn("Done task", content)
+
+    def test_publish_sorted_by_priority(self):
+        task_tracker.cmd_add("Low task", priority="low")
+        task_tracker.cmd_add("High task", priority="high")
+        task_tracker.cmd_add("Medium task", priority="medium")
+        task_tracker.cmd_publish()
+        content = Path("tasks.html").read_text()
+        high_pos = content.index("High task")
+        medium_pos = content.index("Medium task")
+        low_pos = content.index("Low task")
+        self.assertLess(high_pos, medium_pos)
+        self.assertLess(medium_pos, low_pos)
+
+    def test_publish_includes_due_date(self):
+        tasks = [{"id": 1, "title": "Dated task", "status": "open", "priority": "high", "due_date": "2026-05-01"}]
+        task_tracker.save_tasks(tasks)
+        task_tracker.cmd_publish()
+        content = Path("tasks.html").read_text()
+        self.assertIn("2026-05-01", content)
+
+    def test_publish_no_due_date_shows_dash(self):
+        task_tracker.cmd_add("No date task")
+        task_tracker.cmd_publish()
+        content = Path("tasks.html").read_text()
+        self.assertIn("\u2014", content)
+
+    def test_publish_overwrites_existing(self):
+        Path("tasks.html").write_text("old content")
+        task_tracker.cmd_publish()
+        content = Path("tasks.html").read_text()
+        self.assertNotIn("old content", content)
+        self.assertIn("<!DOCTYPE html>", content)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -205,7 +205,7 @@ class TestPublish(unittest.TestCase):
         task_tracker.cmd_done(2)
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_publish()
-        mock_print.assert_called_with("Published 1 tasks to tasks.html")
+        mock_print.assert_called_with("Published 1 task to tasks.html")
         content = Path("tasks.html").read_text()
         self.assertIn("Open task", content)
         self.assertNotIn("Done task", content)


### PR DESCRIPTION
## Summary

- Adds a `publish` command (`python task_tracker.py publish`) that generates a styled `tasks.html` file with all open tasks sorted by priority (high → medium → low)
- Self-contained HTML with inline CSS — no external dependencies
- Includes 8 new test cases covering creation, sorting, empty state, filtering, due dates, and overwrite behavior

## Details

**New function**: `cmd_publish()` in `task_tracker.py`
- Loads tasks, filters to `status == "open"`, sorts by priority rank
- Generates HTML with a styled table (ID, Title, Priority, Due Date columns)
- Uses `html.escape()` on task titles for XSS safety
- Empty state shows "No open tasks" message
- Prints confirmation: `Published N tasks to tasks.html`

**New tests**: `TestPublish` class in `tests/test_task_tracker.py`
- `test_publish_creates_html_file` — file is created
- `test_publish_prints_count` — correct count printed
- `test_publish_empty_tasks` — valid HTML with "No open tasks"
- `test_publish_only_open_tasks` — done tasks excluded
- `test_publish_sorted_by_priority` — high before medium before low
- `test_publish_includes_due_date` — due date shown when set
- `test_publish_no_due_date_shows_dash` — em dash when unset
- `test_publish_overwrites_existing` — silently overwrites

## Test plan

- [x] `python -m py_compile task_tracker.py` — syntax OK
- [x] `python -m unittest tests/test_task_tracker.py -v` — 21/21 tests pass (8 new + 13 existing)
- [x] Manual smoke test with tasks and empty state

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)