### PR TITLE
feat: Add --color flag to CLI list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 python task_tracker.py add "Write tests for task listing"
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --color
 python task_tracker.py done 1
 python task_tracker.py delete 1
 ```

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -170,14 +170,10 @@ def main():
         cmd_add(title, priority, due_date)
 
     elif command == "list":
-        status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
         color = "--color" in args
-        if "--status" in args:
-            idx = args.index("--status")
-            if idx + 1 < len(args):
-                status = args[idx + 1]
+        status, _ = parse_flag(args, "--status")
         cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,6 +9,12 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+PRIORITY_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m"}
+RESET = "\033[0m"
+
+
+def colorize(text, color_code):
+    return f"{color_code}{text}{RESET}"
 
 
 def parse_flag(args, flag):
@@ -52,7 +58,7 @@ def cmd_add(title, priority="medium", due_date=None):
     print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False, sort_due=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -67,7 +73,12 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
         priority = t.get("priority", "medium")
         due_date = t.get("due_date")
         due_str = f" (due: {due_date})" if due_date else ""
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
+        priority_str = f"[{priority}]"
+        if color:
+            color_code = PRIORITY_COLORS.get(priority, "")
+            if color_code:
+                priority_str = colorize(priority_str, color_code)
+        print(f"[{mark}] #{t['id']}: {t['title']} {priority_str}{due_str}")
 
 
 def cmd_done(task_id):
@@ -162,11 +173,12 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
+        color = "--color" in args
         if "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority, sort_due)
+        cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":
         if len(args) < 2:

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -291,6 +291,28 @@ class TestColor(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("[high]", output)
 
+    def test_color_backward_compat_no_priority_key(self):
+        tasks = [{"id": 1, "title": "Old task", "status": "open"}]
+        task_tracker.save_tasks(tasks)
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[33m", output)   # medium → yellow
+        self.assertIn("[medium]", output)
+        self.assertIn("\033[0m", output)
+
+    def test_color_flag_wires_through_main(self):
+        task_tracker.cmd_add("Urgent", priority="high")
+        with patch("sys.argv", ["task_tracker.py", "list", "--color"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)
+
+    def test_colorize_wraps_with_code_and_reset(self):
+        result = task_tracker.colorize("[high]", "\033[31m")
+        self.assertEqual(result, "\033[31m[high]\033[0m")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -243,5 +243,54 @@ class TestPublish(unittest.TestCase):
         self.assertIn("<!DOCTYPE html>", content)
 
 
+class TestColor(unittest.TestCase):
+    def setUp(self):
+        task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def tearDown(self):
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def test_color_high_contains_red_ansi(self):
+        task_tracker.cmd_add("Urgent", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)
+        self.assertIn("\033[0m", output)
+
+    def test_color_medium_contains_yellow_ansi(self):
+        task_tracker.cmd_add("Normal", priority="medium")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[33m", output)
+        self.assertIn("\033[0m", output)
+
+    def test_color_low_contains_green_ansi(self):
+        task_tracker.cmd_add("Minor", priority="low")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[32m", output)
+        self.assertIn("\033[0m", output)
+
+    def test_no_color_no_ansi_codes(self):
+        task_tracker.cmd_add("Task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=False)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_color_still_shows_priority_label(self):
+        task_tracker.cmd_add("Task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("[high]", output)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `--color` flag to `task list` command that renders priority labels with ANSI colors: `[high]` in red, `[medium]` in yellow, `[low]` in green
- Default output (without `--color`) is unchanged — plain text as before
- Adds 5 unit tests covering all priority colors, no-color mode, and label preservation

## Test plan

- [x] All 34 tests pass (29 existing + 5 new)
- [x] Syntax check passes
- [ ] Manual smoke test: `python3 task_tracker.py list --color` shows colored priorities
- [ ] Manual smoke test: `python3 task_tracker.py list` shows plain text (unchanged)

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)