### PR TITLE
feat: add --color flag to CLI list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,28 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 
 ```bash
 python task_tracker.py add "Write tests for task listing"
+python task_tracker.py add "Fix bug" --priority high --due-date 2026-05-01
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --priority
+python task_tracker.py list --sort-due
+python task_tracker.py list --color
 python task_tracker.py done 1
 python task_tracker.py delete 1
+python task_tracker.py publish
 ```
+
+### Flags
+
+| Command | Flag | Description |
+|---------|------|-------------|
+| `add` | `--priority high\|medium\|low` | Set task priority (default: medium) |
+| `add` | `--due-date YYYY-MM-DD` | Set task due date |
+| `list` | `--status open\|done` | Filter by status |
+| `list` | `--priority` | Sort by priority (high first) |
+| `list` | `--sort-due` | Sort by due date (earliest first, no-date last) |
+| `list` | `--color` | Colorize priority tags (red/yellow/green) |
+| `list` | `--no-color` | No-op; disables color for script compatibility |
 
 ## Development
 

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+ANSI_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m", "reset": "\033[0m"}
 
 
 def parse_flag(args, flag):
@@ -52,7 +53,7 @@ def cmd_add(title, priority="medium", due_date=None):
     print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False, sort_due=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -67,7 +68,13 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
         priority = t.get("priority", "medium")
         due_date = t.get("due_date")
         due_str = f" (due: {due_date})" if due_date else ""
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
+        if color:
+            col = ANSI_COLORS.get(priority, "")
+            reset = ANSI_COLORS["reset"]
+            priority_tag = f"{col}[{priority}]{reset}"
+        else:
+            priority_tag = f"[{priority}]"
+        print(f"[{mark}] #{t['id']}: {t['title']} {priority_tag}{due_str}")
 
 
 def cmd_done(task_id):
@@ -162,11 +169,12 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
+        color = "--color" in args
         if "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority, sort_due)
+        cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":
         if len(args) < 2:

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -160,21 +160,16 @@ def main():
             sys.exit(1)
         add_args = args[1:]
         priority, add_args = parse_flag(add_args, "--priority")
-        if priority is None:
-            priority = "medium"
+        priority = priority or "medium"
         due_date, add_args = parse_flag(add_args, "--due-date")
         title = " ".join(add_args)
         cmd_add(title, priority, due_date)
 
     elif command == "list":
-        status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
         color = "--color" in args
-        if "--status" in args:
-            idx = args.index("--status")
-            if idx + 1 < len(args):
-                status = args[idx + 1]
+        status, _ = parse_flag(args, "--status")
         cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+# ANSI 8-color escape codes keyed by priority; "reset" restores default terminal color.
 ANSI_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m", "reset": "\033[0m"}
 
 
@@ -70,7 +71,7 @@ def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
         due_str = f" (due: {due_date})" if due_date else ""
         if color:
             col = ANSI_COLORS.get(priority, "")
-            reset = ANSI_COLORS["reset"]
+            reset = ANSI_COLORS["reset"] if col else ""
             priority_tag = f"{col}[{priority}]{reset}"
         else:
             priority_tag = f"[{priority}]"

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -167,6 +167,45 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("(due:", output)
 
+    def test_list_color_high_contains_ansi(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)
+        self.assertIn("[high]", output)
+        self.assertIn("\033[0m", output)
+
+    def test_list_color_medium_contains_ansi(self):
+        task_tracker.cmd_add("Normal task", priority="medium")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[33m", output)
+        self.assertIn("[medium]", output)
+
+    def test_list_color_low_contains_ansi(self):
+        task_tracker.cmd_add("Minor task", priority="low")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[32m", output)
+        self.assertIn("[low]", output)
+
+    def test_list_no_color_flag_no_ansi(self):
+        task_tracker.cmd_add("Task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=False)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_list_color_default_is_off(self):
+        task_tracker.cmd_add("Task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
 
 class TestPublish(unittest.TestCase):
     def setUp(self):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -183,6 +183,7 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[33m", output)
         self.assertIn("[medium]", output)
+        self.assertIn("\033[0m", output)
 
     def test_list_color_low_contains_ansi(self):
         task_tracker.cmd_add("Minor task", priority="low")
@@ -191,6 +192,7 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[32m", output)
         self.assertIn("[low]", output)
+        self.assertIn("\033[0m", output)
 
     def test_list_no_color_flag_no_ansi(self):
         task_tracker.cmd_add("Task", priority="high")
@@ -203,6 +205,23 @@ class TestTaskTracker(unittest.TestCase):
         task_tracker.cmd_add("Task", priority="high")
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_list()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_main_color_flag_passes_ansi_to_output(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print, \
+             patch("sys.argv", ["task_tracker.py", "list", "--color"]):
+            task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)
+        self.assertIn("\033[0m", output)
+
+    def test_list_no_color_flag_is_noop(self):
+        task_tracker.cmd_add("Task", priority="high")
+        with patch("sys.argv", ["task_tracker.py", "list", "--no-color"]), \
+             patch("builtins.print") as mock_print:
+            task_tracker.main()
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("\033[", output)
 


### PR DESCRIPTION
## Summary

- Adds `--color` flag to `task_tracker.py list` that colors priority tags using ANSI escape codes: HIGH in red, MEDIUM in yellow, LOW in green
- Color is off by default; `--no-color` accepted as a no-op for script compatibility
- Adds 5 new unit tests covering all priority colors, default-off, and explicit no-color behavior

Fixes #8

## Test plan

- [x] `python3 -m py_compile task_tracker.py` — compiles clean
- [x] `python3 -m unittest tests/test_task_tracker.py -v` — all 34 tests pass
- [ ] Manual: `python3 task_tracker.py list --color` shows colored priority tags in terminal
- [ ] Manual: `python3 task_tracker.py list` shows plain text (no ANSI codes)
- [ ] Manual: `python3 task_tracker.py list --no-color` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)