### PR TITLE
feat: Add --done flag to filter completed tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 python task_tracker.py add "Write tests for task listing"
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --done
 python task_tracker.py done 1
 python task_tracker.py delete 1
 ```

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -162,7 +162,9 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
-        if "--status" in args:
+        if "--done" in args:
+            status = "done"
+        elif "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -167,6 +167,20 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("(due:", output)
 
+    def test_list_done_flag_shows_only_done_tasks(self):
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(status="done")
+        self.assertEqual(mock_print.call_count, 1)
+
+    def test_list_done_flag_no_done_tasks(self):
+        task_tracker.cmd_add("Open task")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(status="done")
+        mock_print.assert_called_with("No tasks found.")
+
 
 class TestPublish(unittest.TestCase):
     def setUp(self):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -188,9 +188,8 @@ class TestTaskTracker(unittest.TestCase):
         task_tracker.cmd_add("Open task")
         task_tracker.cmd_add("Done task")
         task_tracker.cmd_done(2)
-        with patch("sys.argv", ["task_tracker.py", "list", "--done"]):
-            with patch("builtins.print") as mock_print:
-                task_tracker.main()
+        with patch("sys.argv", ["task_tracker.py", "list", "--done"]), patch("builtins.print") as mock_print:
+            task_tracker.main()
         self.assertEqual(mock_print.call_count, 1)
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("Done task", output)

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -174,12 +174,27 @@ class TestTaskTracker(unittest.TestCase):
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_list(status="done")
         self.assertEqual(mock_print.call_count, 1)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("Done task", output)
 
     def test_list_done_flag_no_done_tasks(self):
         task_tracker.cmd_add("Open task")
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_list(status="done")
         mock_print.assert_called_with("No tasks found.")
+
+    def test_list_done_flag_cli_integration(self):
+        """--done flag in main() sets status="done" and routes to cmd_list correctly."""
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("sys.argv", ["task_tracker.py", "list", "--done"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        self.assertEqual(mock_print.call_count, 1)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("Done task", output)
+        self.assertNotIn("Open task", output)
 
 
 class TestPublish(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Adds a `--done` boolean flag to the `list` command as a shortcut for `--status done`
- When `--done` and `--status` are both present, `--done` takes priority
- Includes 2 new tests and README documentation

## Test plan

- [x] `python3 task_tracker.py list --done` shows only completed tasks
- [x] `python3 task_tracker.py list --done` with no done tasks prints "No tasks found."
- [x] Existing `--status done` still works (no regression)
- [x] Full test suite passes (31/31)

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>