### PR TITLE
feat: Add --color flag to CLI output (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 
 ```bash
 python task_tracker.py add "Write tests for task listing"
+python task_tracker.py add "Deploy release" --priority high --due-date 2026-05-01
+
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --priority          # sort by priority
+python task_tracker.py list --sort-due          # sort by due date
+python task_tracker.py list --color             # ANSI color on priority tags
+python task_tracker.py list --no-color          # force plain output
+
 python task_tracker.py done 1
 python task_tracker.py delete 1
 ```

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,6 +9,12 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+PRIORITY_COLORS = {
+    "high":   "\033[31m",
+    "medium": "\033[33m",
+    "low":    "\033[32m",
+}
+ANSI_RESET = "\033[0m"
 
 
 def parse_flag(args, flag):
@@ -37,6 +43,13 @@ def next_id(tasks):
     return max((t["id"] for t in tasks), default=0) + 1
 
 
+def colorize(text, code):
+    """Wrap text in an ANSI color code followed by reset. No-op if code is falsy."""
+    if not code:
+        return text
+    return f"{code}{text}{ANSI_RESET}"
+
+
 def cmd_add(title, priority="medium", due_date=None):
     if due_date is not None:
         try:
@@ -52,7 +65,7 @@ def cmd_add(title, priority="medium", due_date=None):
     print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False, sort_due=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -67,7 +80,8 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
         priority = t.get("priority", "medium")
         due_date = t.get("due_date")
         due_str = f" (due: {due_date})" if due_date else ""
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
+        priority_tag = colorize(f"[{priority}]", PRIORITY_COLORS.get(priority) if color else None)
+        print(f"[{mark}] #{t['id']}: {t['title']} {priority_tag}{due_str}")
 
 
 def cmd_done(task_id):
@@ -162,11 +176,12 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
+        color = "--color" in args and "--no-color" not in args
         if "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority, sort_due)
+        cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":
         if len(args) < 2:

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -112,16 +112,17 @@ def cmd_publish():
     open_tasks.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
 
     if open_tasks:
-        rows = ""
+        row_parts = []
         for t in open_tasks:
             priority = t.get("priority", "medium")
             due_date = html.escape(t.get("due_date") or "\u2014")
-            rows += (
+            row_parts.append(
                 f'<tr><td>{t["id"]}</td>'
                 f"<td>{html.escape(t['title'])}</td>"
                 f'<td class="{priority}">{priority}</td>'
                 f"<td>{due_date}</td></tr>\n"
             )
+        rows = "".join(row_parts)
         body_content = (
             "<table>\n<thead><tr>"
             "<th>ID</th><th>Title</th><th>Priority</th><th>Due Date</th>"

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -183,6 +183,7 @@ class TestTaskTracker(unittest.TestCase):
             task_tracker.cmd_list(color=True)
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[33m", output)   # yellow
+        self.assertIn("\033[0m", output)    # reset
 
     def test_list_color_low_contains_ansi(self):
         task_tracker.cmd_add("Low task", priority="low")
@@ -190,6 +191,7 @@ class TestTaskTracker(unittest.TestCase):
             task_tracker.cmd_list(color=True)
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[32m", output)   # green
+        self.assertIn("\033[0m", output)    # reset
 
     def test_list_no_color_default_no_ansi(self):
         task_tracker.cmd_add("Plain task", priority="high")
@@ -198,12 +200,44 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("\033[", output)
 
-    def test_list_color_still_shows_priority_text(self):
-        task_tracker.cmd_add("Tagged task", priority="high")
-        with patch("builtins.print") as mock_print:
-            task_tracker.cmd_list(color=True)
+class TestColorize(unittest.TestCase):
+    def test_colorize_wraps_text(self):
+        result = task_tracker.colorize("hello", "\033[31m")
+        self.assertEqual(result, "\033[31m" + "hello" + "\033[0m")
+
+    def test_colorize_noop_when_code_none(self):
+        self.assertEqual(task_tracker.colorize("hello", None), "hello")
+
+    def test_colorize_noop_when_code_empty(self):
+        self.assertEqual(task_tracker.colorize("hello", ""), "hello")
+
+
+class TestMainColorFlag(unittest.TestCase):
+    def setUp(self):
+        task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+        task_tracker.cmd_add("Urgent task", priority="high")
+
+    def tearDown(self):
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def test_main_color_flag_emits_ansi(self):
+        """--color flag passed through main() reaches cmd_list."""
+        with patch("sys.argv", ["task_tracker.py", "list", "--color"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
         output = mock_print.call_args_list[0][0][0]
-        self.assertIn("[high]", output)
+        self.assertIn("\033[31m", output)
+
+    def test_main_no_color_flag_suppresses_ansi(self):
+        """--no-color prevents ANSI even when --color is also present."""
+        with patch("sys.argv", ["task_tracker.py", "list", "--color", "--no-color"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
 
 
 class TestPublish(unittest.TestCase):

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -168,6 +168,44 @@ class TestTaskTracker(unittest.TestCase):
         self.assertNotIn("(due:", output)
 
 
+    def test_list_color_high_contains_ansi(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)   # red
+        self.assertIn("\033[0m", output)    # reset
+        self.assertIn("[high]", output)
+
+    def test_list_color_medium_contains_ansi(self):
+        task_tracker.cmd_add("Normal task", priority="medium")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[33m", output)   # yellow
+
+    def test_list_color_low_contains_ansi(self):
+        task_tracker.cmd_add("Low task", priority="low")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[32m", output)   # green
+
+    def test_list_no_color_default_no_ansi(self):
+        task_tracker.cmd_add("Plain task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list()          # color=False by default
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_list_color_still_shows_priority_text(self):
+        task_tracker.cmd_add("Tagged task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("[high]", output)
+
+
 class TestPublish(unittest.TestCase):
     def setUp(self):
         task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -167,7 +167,6 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("(due:", output)
 
-
     def test_list_color_high_contains_ansi(self):
         task_tracker.cmd_add("Urgent task", priority="high")
         with patch("builtins.print") as mock_print:
@@ -199,6 +198,7 @@ class TestTaskTracker(unittest.TestCase):
             task_tracker.cmd_list()          # color=False by default
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("\033[", output)
+
 
 class TestColorize(unittest.TestCase):
     def test_colorize_wraps_text(self):


### PR DESCRIPTION
## Summary

- Adds `--color` / `--no-color` flags to `task list` command
- Priority tags are rendered with ANSI colors: red (high), yellow (medium), green (low)
- Plain text output remains the default; `--no-color` takes precedence over `--color`

## Changes

| File | Change |
|------|--------|
| `task_tracker.py` | Added `PRIORITY_COLORS`/`ANSI_RESET` constants, `colorize()` helper, extended `cmd_list()` with `color` param, flag detection in `main()` |
| `tests/test_task_tracker.py` | Added 5 tests for color output (high/medium/low ANSI codes, no-color default, priority text preserved) |

## Test plan

- [x] All 29 existing tests pass (no regressions)
- [x] 5 new color tests pass
- [x] Syntax check passes
- [ ] Manual smoke test: `python3 task_tracker.py list --color` shows colored priority tags

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)