### PR TITLE
feat: Add --color flag to CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 - Add, list, complete, and delete tasks
 - Persist tasks to a local JSON file
 - Filter tasks by status
+- Colorized priority output (`--color` flag)
 
 ## Usage
 
@@ -17,6 +18,8 @@ python task_tracker.py list
 python task_tracker.py list --status open
 python task_tracker.py done 1
 python task_tracker.py delete 1
+python task_tracker.py list --color
+python task_tracker.py list --color --no-color
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ python task_tracker.py list
 python task_tracker.py list --status open
 python task_tracker.py done 1
 python task_tracker.py delete 1
-python task_tracker.py list --color
-python task_tracker.py list --color --no-color
+python task_tracker.py list --color          # colorized priority output
+python task_tracker.py list --no-color       # suppress color (useful for scripting/piping)
 ```
 
 ## Development

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -123,25 +123,33 @@ def cmd_publish():
         body_content = (
             "<table>\n<thead><tr>"
             "<th>ID</th><th>Title</th><th>Priority</th><th>Due Date</th>"
-            "</tr></thead>\n<tbody>\n" + rows + "</tbody>\n</table>"
+            f"</tr></thead>\n<tbody>\n{rows}</tbody>\n</table>"
         )
     else:
         body_content = "<p>No open tasks.</p>"
 
-    page = (
-        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
-        '<meta charset="UTF-8">\n<title>Open Tasks</title>\n<style>\n'
-        "body { font-family: sans-serif; max-width: 800px; margin: 2rem auto; }\n"
-        "table { border-collapse: collapse; width: 100%; }\n"
-        "th, td { border: 1px solid #ccc; padding: 0.5rem 1rem; text-align: left; }\n"
-        "th { background: #f5f5f5; }\n"
-        ".high { color: #c0392b; font-weight: bold; }\n"
-        ".medium { color: #e67e22; }\n"
-        ".low { color: #27ae60; }\n"
-        "</style>\n</head>\n<body>\n"
-        f"<h1>Open Tasks</h1>\n{body_content}\n"
-        "</body>\n</html>\n"
-    )
+    page = f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Open Tasks</title>
+<style>
+body {{ font-family: sans-serif; max-width: 800px; margin: 2rem auto; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #ccc; padding: 0.5rem 1rem; text-align: left; }}
+th {{ background: #f5f5f5; }}
+.high {{ color: #c0392b; font-weight: bold; }}
+.medium {{ color: #e67e22; }}
+.low {{ color: #27ae60; }}
+</style>
+</head>
+<body>
+<h1>Open Tasks</h1>
+{body_content}
+</body>
+</html>
+"""
 
     Path("tasks.html").write_text(page)
     count = len(open_tasks)

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
-ANSI_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m"}
+ANSI_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m"}  # red, yellow, green
 ANSI_RESET = "\033[0m"
 
 
@@ -26,6 +26,7 @@ def parse_flag(args, flag):
 
 
 def colorize(priority, use_color):
+    """Wrap priority string in ANSI color codes. Returns plain priority if use_color is False or priority is unknown."""
     if not use_color:
         return priority
     color = ANSI_COLORS.get(priority, "")

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+ANSI_COLORS = {"high": "\033[31m", "medium": "\033[33m", "low": "\033[32m"}
+ANSI_RESET = "\033[0m"
 
 
 def parse_flag(args, flag):
@@ -21,6 +23,15 @@ def parse_flag(args, flag):
     value = args[idx + 1]
     remaining = args[:idx] + args[idx + 2:]
     return value, remaining
+
+
+def colorize(priority, use_color):
+    if not use_color:
+        return priority
+    color = ANSI_COLORS.get(priority, "")
+    if color:
+        return f"{color}{priority}{ANSI_RESET}"
+    return priority
 
 
 def load_tasks():
@@ -52,7 +63,7 @@ def cmd_add(title, priority="medium", due_date=None):
     print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False, sort_due=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -67,7 +78,7 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
         priority = t.get("priority", "medium")
         due_date = t.get("due_date")
         due_str = f" (due: {due_date})" if due_date else ""
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
+        print(f"[{mark}] #{t['id']}: {t['title']} [{colorize(priority, color)}]{due_str}")
 
 
 def cmd_done(task_id):
@@ -162,11 +173,12 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
+        color = "--color" in args and "--no-color" not in args
         if "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority, sort_due)
+        cmd_list(status, sort_priority, sort_due, color)
 
     elif command == "done":
         if len(args) < 2:

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -168,6 +168,42 @@ class TestTaskTracker(unittest.TestCase):
         self.assertNotIn("(due:", output)
 
 
+    def test_colorize_with_color_enabled(self):
+        result = task_tracker.colorize("high", use_color=True)
+        self.assertIn("\033[31m", result)
+        self.assertIn("high", result)
+        self.assertIn("\033[0m", result)
+
+    def test_colorize_without_color(self):
+        result = task_tracker.colorize("high", use_color=False)
+        self.assertEqual(result, "high")
+
+    def test_colorize_medium_color(self):
+        result = task_tracker.colorize("medium", use_color=True)
+        self.assertIn("\033[33m", result)
+
+    def test_colorize_low_color(self):
+        result = task_tracker.colorize("low", use_color=True)
+        self.assertIn("\033[32m", result)
+
+    def test_list_with_color_wraps_priority(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[31m", output)
+        self.assertIn("high", output)
+        self.assertIn("\033[0m", output)
+
+    def test_list_without_color_no_ansi(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=False)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+        self.assertIn("[high]", output)
+
+
 class TestPublish(unittest.TestCase):
     def setUp(self):
         task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -203,6 +203,21 @@ class TestTaskTracker(unittest.TestCase):
         self.assertNotIn("\033[", output)
         self.assertIn("[high]", output)
 
+    def test_colorize_unknown_priority_no_ansi(self):
+        # Unknown priority should return plain string, not crash or leak ANSI
+        result = task_tracker.colorize("critical", use_color=True)
+        self.assertEqual(result, "critical")
+        self.assertNotIn("\033[", result)
+
+    def test_main_color_overridden_by_no_color(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("sys.argv", ["task_tracker.py", "list", "--color", "--no-color"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+        self.assertIn("[high]", output)
+
 
 class TestPublish(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

- Adds `--color` flag to `task list` command that colorizes priority tags: high (red), medium (yellow), low (green)
- Adds `--no-color` override flag for scripting/piping contexts
- Adds `colorize()` helper function and ANSI color constants to `task_tracker.py`
- 6 new unit tests covering colorize behavior and list output with/without color

## Test plan

- [x] All 35 tests pass (`python3 -m pytest tests/test_task_tracker.py -v`)
- [x] Syntax check passes (`python3 -m py_compile task_tracker.py`)
- [ ] Manual smoke test: `python task_tracker.py list --color` shows colored priorities
- [ ] Manual smoke test: `python task_tracker.py list` shows plain text (unchanged)
- [ ] Manual smoke test: `python task_tracker.py list --color --no-color` shows plain text

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)