### PR TITLE
feat: Add --done flag to filter completed tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 python task_tracker.py add "Write tests for task listing"
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --done
 python task_tracker.py done 1
 python task_tracker.py delete 1
 ```

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -98,11 +98,11 @@ def cmd_publish():
     open_tasks.sort(key=lambda t: PRIORITY_RANK.get(t.get("priority", "medium"), 1))
 
     if open_tasks:
-        rows = ""
+        row_parts = []
         for t in open_tasks:
             priority = t.get("priority", "medium")
             due_date = html.escape(t.get("due_date") or "\u2014")
-            rows += (
+            row_parts.append(
                 f'<tr><td>{t["id"]}</td>'
                 f"<td>{html.escape(t['title'])}</td>"
                 f'<td class="{priority}">{priority}</td>'
@@ -111,7 +111,7 @@ def cmd_publish():
         body_content = (
             "<table>\n<thead><tr>"
             "<th>ID</th><th>Title</th><th>Priority</th><th>Due Date</th>"
-            "</tr></thead>\n<tbody>\n" + rows + "</tbody>\n</table>"
+            "</tr></thead>\n<tbody>\n" + "".join(row_parts) + "</tbody>\n</table>"
         )
     else:
         body_content = "<p>No open tasks.</p>"
@@ -152,8 +152,7 @@ def main():
             sys.exit(1)
         add_args = args[1:]
         priority, add_args = parse_flag(add_args, "--priority")
-        if priority is None:
-            priority = "medium"
+        priority = priority or "medium"
         due_date, add_args = parse_flag(add_args, "--due-date")
         title = " ".join(add_args)
         cmd_add(title, priority, due_date)

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -162,7 +162,9 @@ def main():
         status = None
         sort_priority = "--priority" in args
         sort_due = "--sort-due" in args
-        if "--status" in args:
+        if "--done" in args:
+            status = "done"
+        elif "--status" in args:
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -50,7 +50,7 @@ class TestTaskTracker(unittest.TestCase):
             task_tracker.cmd_list(status="open")
         self.assertEqual(mock_print.call_count, 1)
 
-    def test_list_done_flag(self):
+    def test_list_status_done(self):
         task_tracker.cmd_add("Open task")
         task_tracker.cmd_add("Done task")
         task_tracker.cmd_done(2)
@@ -60,11 +60,35 @@ class TestTaskTracker(unittest.TestCase):
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("Done task", output)
 
-    def test_list_done_flag_no_done_tasks(self):
+    def test_list_status_done_no_results(self):
         task_tracker.cmd_add("Open task")
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_list(status="done")
         mock_print.assert_called_with("No tasks found.")
+
+    def test_main_list_done_flag(self):
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("sys.argv", ["task_tracker.py", "list", "--done"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        self.assertEqual(mock_print.call_count, 1)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("Done task", output)
+        self.assertNotIn("Open task", output)
+
+    def test_main_done_flag_overrides_status(self):
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("sys.argv", ["task_tracker.py", "list", "--status", "open", "--done"]):
+            with patch("builtins.print") as mock_print:
+                task_tracker.main()
+        self.assertEqual(mock_print.call_count, 1)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("Done task", output)
+        self.assertNotIn("Open task", output)
 
     def test_done(self):
         task_tracker.cmd_add("Complete me")

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -50,6 +50,22 @@ class TestTaskTracker(unittest.TestCase):
             task_tracker.cmd_list(status="open")
         self.assertEqual(mock_print.call_count, 1)
 
+    def test_list_done_flag(self):
+        task_tracker.cmd_add("Open task")
+        task_tracker.cmd_add("Done task")
+        task_tracker.cmd_done(2)
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(status="done")
+        self.assertEqual(mock_print.call_count, 1)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("Done task", output)
+
+    def test_list_done_flag_no_done_tasks(self):
+        task_tracker.cmd_add("Open task")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(status="done")
+        mock_print.assert_called_with("No tasks found.")
+
     def test_done(self):
         task_tracker.cmd_add("Complete me")
         task_tracker.cmd_done(1)


### PR DESCRIPTION
## Summary

- Adds `--done` shorthand flag to the `list` command, filtering output to show only completed tasks
- Follows existing boolean flag pattern (`--priority`, `--sort-due`) — `--done` sets `status="done"` and takes precedence over `--status`
- Adds 2 unit tests: done flag filtering and empty-result edge case

## Test plan

- [x] All 31 tests pass (`python3 -m pytest tests/test_task_tracker.py -v`)
- [x] CLI smoke test: `task_tracker.py list --done` shows only done tasks
- [x] `--status done` still works unchanged
- [x] `list` with no flags still shows all tasks

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)