### PR TITLE
feat: Add --color flag to CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 python task_tracker.py add "Write tests for task listing"
 python task_tracker.py list
 python task_tracker.py list --status open
+python task_tracker.py list --color
+python task_tracker.py list --status open --color
+python task_tracker.py add "Fix login bug" --priority high --color
 python task_tracker.py done 1
 python task_tracker.py delete 1
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built incrementally by the AI Dark Factory (Archon-based coding factory).
 - Add, list, complete, and delete tasks
 - Persist tasks to a local JSON file
 - Filter tasks by status
+- Colorized priority labels via `--color` flag (ANSI terminal output)
 
 ## Usage
 

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -19,8 +19,16 @@ PRIORITY_COLORS = {
 
 
 def colorize_priority(priority, color):
+    """Return the priority label wrapped in ANSI color codes if color is True.
+
+    Falls back to plain ``[{priority}]`` when color is False or when
+    the priority value is not present in PRIORITY_COLORS.
+    If you add a new priority to PRIORITY_RANK, also add it here.
+    """
     if not color:
         return f"[{priority}]"
+    # Falls back to plain text for any priority not in PRIORITY_COLORS.
+    # If you add a new priority to PRIORITY_RANK, also add it here.
     code = PRIORITY_COLORS.get(priority, "")
     return f"{code}[{priority}]{ANSI_RESET}" if code else f"[{priority}]"
 

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -10,6 +10,20 @@ from pathlib import Path
 TASKS_FILE = Path("tasks.json")
 PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
 
+ANSI_RESET = "\033[0m"
+PRIORITY_COLORS = {
+    "high":   "\033[1;31m",
+    "medium": "\033[33m",
+    "low":    "\033[32m",
+}
+
+
+def colorize_priority(priority, color):
+    if not color:
+        return f"[{priority}]"
+    code = PRIORITY_COLORS.get(priority, "")
+    return f"{code}[{priority}]{ANSI_RESET}" if code else f"[{priority}]"
+
 
 def parse_flag(args, flag):
     """Extract a flag value from args list. Returns (value_or_none, remaining_args)."""
@@ -37,7 +51,7 @@ def next_id(tasks):
     return max((t["id"] for t in tasks), default=0) + 1
 
 
-def cmd_add(title, priority="medium", due_date=None):
+def cmd_add(title, priority="medium", due_date=None, color=False):
     if due_date is not None:
         try:
             datetime.date.fromisoformat(due_date)
@@ -49,10 +63,10 @@ def cmd_add(title, priority="medium", due_date=None):
     tasks.append(task)
     save_tasks(tasks)
     due_str = f" (due: {due_date})" if due_date else ""
-    print(f"Added task #{task['id']}: {title} [{priority}]{due_str}")
+    print(f"Added task #{task['id']}: {title} {colorize_priority(priority, color)}{due_str}")
 
 
-def cmd_list(status=None, sort_priority=False, sort_due=False):
+def cmd_list(status=None, sort_priority=False, sort_due=False, color=False):
     tasks = load_tasks()
     filtered = [t for t in tasks if status is None or t["status"] == status]
     if not filtered:
@@ -67,7 +81,7 @@ def cmd_list(status=None, sort_priority=False, sort_due=False):
         priority = t.get("priority", "medium")
         due_date = t.get("due_date")
         due_str = f" (due: {due_date})" if due_date else ""
-        print(f"[{mark}] #{t['id']}: {t['title']} [{priority}]{due_str}")
+        print(f"[{mark}] #{t['id']}: {t['title']} {colorize_priority(priority, color)}{due_str}")
 
 
 def cmd_done(task_id):
@@ -139,6 +153,9 @@ def cmd_publish():
 
 def main():
     args = sys.argv[1:]
+    color = "--color" in args
+    if color:
+        args = [a for a in args if a != "--color"]
     if not args:
         print("Usage: task_tracker.py <command> [args]")
         print("Commands: add, list, done, delete, publish")
@@ -156,7 +173,7 @@ def main():
             priority = "medium"
         due_date, add_args = parse_flag(add_args, "--due-date")
         title = " ".join(add_args)
-        cmd_add(title, priority, due_date)
+        cmd_add(title, priority, due_date, color=color)
 
     elif command == "list":
         status = None
@@ -166,7 +183,7 @@ def main():
             idx = args.index("--status")
             if idx + 1 < len(args):
                 status = args[idx + 1]
-        cmd_list(status, sort_priority, sort_due)
+        cmd_list(status, sort_priority, sort_due, color=color)
 
     elif command == "done":
         if len(args) < 2:

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -27,8 +27,6 @@ def colorize_priority(priority, color):
     """
     if not color:
         return f"[{priority}]"
-    # Falls back to plain text for any priority not in PRIORITY_COLORS.
-    # If you add a new priority to PRIORITY_RANK, also add it here.
     code = PRIORITY_COLORS.get(priority, "")
     return f"{code}[{priority}]{ANSI_RESET}" if code else f"[{priority}]"
 
@@ -67,7 +65,13 @@ def cmd_add(title, priority="medium", due_date=None, color=False):
             print("Invalid due-date format. Use YYYY-MM-DD.")
             return
     tasks = load_tasks()
-    task = {"id": next_id(tasks), "title": title, "status": "open", "priority": priority, "due_date": due_date}
+    task = {
+        "id": next_id(tasks),
+        "title": title,
+        "status": "open",
+        "priority": priority,
+        "due_date": due_date,
+    }
     tasks.append(task)
     save_tasks(tasks)
     due_str = f" (due: {due_date})" if due_date else ""

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -243,5 +243,65 @@ class TestPublish(unittest.TestCase):
         self.assertIn("<!DOCTYPE html>", content)
 
 
+class TestColorFlag(unittest.TestCase):
+    def setUp(self):
+        task_tracker.TASKS_FILE = Path("/tmp/test_tasks.json")
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def tearDown(self):
+        if task_tracker.TASKS_FILE.exists():
+            task_tracker.TASKS_FILE.unlink()
+
+    def test_no_color_default(self):
+        task_tracker.cmd_add("Plain task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=False)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_color_high_priority(self):
+        task_tracker.cmd_add("Urgent task", priority="high")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[1;31m", output)
+        self.assertIn("\033[0m", output)
+
+    def test_color_medium_priority(self):
+        task_tracker.cmd_add("Normal task", priority="medium")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[33m", output)
+
+    def test_color_low_priority(self):
+        task_tracker.cmd_add("Minor task", priority="low")
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_list(color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[32m", output)
+
+    def test_color_add_task(self):
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_add("Color task", priority="high", color=True)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[", output)
+
+    def test_color_add_no_color(self):
+        with patch("builtins.print") as mock_print:
+            task_tracker.cmd_add("Plain task", priority="high", color=False)
+        output = mock_print.call_args_list[0][0][0]
+        self.assertNotIn("\033[", output)
+
+    def test_color_flag_main_list(self):
+        task_tracker.cmd_add("Main test task", priority="high")
+        with patch("builtins.print") as mock_print, \
+             patch.object(sys, "argv", ["task_tracker.py", "list", "--color"]):
+            task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[", output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_task_tracker.py
+++ b/tests/test_task_tracker.py
@@ -254,9 +254,11 @@ class TestColorFlag(unittest.TestCase):
             task_tracker.TASKS_FILE.unlink()
 
     def test_no_color_default(self):
-        task_tracker.cmd_add("Plain task", priority="high")
+        with patch("builtins.print"):
+            task_tracker.cmd_add("Plain task", priority="high")
         with patch("builtins.print") as mock_print:
             task_tracker.cmd_list(color=False)
+        self.assertEqual(len(mock_print.call_args_list), 1)
         output = mock_print.call_args_list[0][0][0]
         self.assertNotIn("\033[", output)
 
@@ -274,6 +276,7 @@ class TestColorFlag(unittest.TestCase):
             task_tracker.cmd_list(color=True)
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[33m", output)
+        self.assertIn("\033[0m", output)
 
     def test_color_low_priority(self):
         task_tracker.cmd_add("Minor task", priority="low")
@@ -281,6 +284,7 @@ class TestColorFlag(unittest.TestCase):
             task_tracker.cmd_list(color=True)
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[32m", output)
+        self.assertIn("\033[0m", output)
 
     def test_color_add_task(self):
         with patch("builtins.print") as mock_print:
@@ -301,6 +305,23 @@ class TestColorFlag(unittest.TestCase):
             task_tracker.main()
         output = mock_print.call_args_list[0][0][0]
         self.assertIn("\033[", output)
+
+    def test_color_flag_main_add(self):
+        with patch("builtins.print") as mock_print, \
+             patch.object(sys, "argv", ["task_tracker.py", "add", "Color task",
+                                        "--priority", "high", "--color"]):
+            task_tracker.main()
+        output = mock_print.call_args_list[0][0][0]
+        self.assertIn("\033[", output)
+
+    def test_colorize_unknown_priority_returns_plain(self):
+        result = task_tracker.colorize_priority("critical", color=True)
+        self.assertEqual(result, "[critical]")
+        self.assertNotIn("\033[", result)
+
+    def test_colorize_unknown_priority_no_color(self):
+        result = task_tracker.colorize_priority("critical", color=False)
+        self.assertEqual(result, "[critical]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `--color` CLI flag that colorizes priority labels using ANSI escape codes (high=red/bold, medium=yellow, low=green)
- Default behavior remains plain text for backward compatibility and piped output
- No external dependencies — uses Python stdlib ANSI escape sequences

## Changes

- `task_tracker.py`: Added `colorize_priority()` helper, `color` param to `cmd_add`/`cmd_list`, `--color` flag stripping in `main()`
- `tests/test_task_tracker.py`: Added `TestColorFlag` class with 7 test cases
- `README.md`: Added `--color` usage examples

## Test plan

- [x] All 36 tests pass (29 existing + 7 new)
- [x] Syntax check passes
- [ ] Manual: `python task_tracker.py list --color` shows colored priority labels
- [ ] Manual: `python task_tracker.py list` (no flag) shows plain text as before

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)